### PR TITLE
Fixed issue with down arrow navigation

### DIFF
--- a/jquery.smart_autocomplete.js
+++ b/jquery.smart_autocomplete.js
@@ -402,7 +402,7 @@
             if(current_selection >= 0)
               $(options.context).trigger('itemUnfocus', result_suggestions[current_selection] );
 
-            if(isNaN(current_selection) || (++current_selection >= result_suggestions.length) )
+            if(isNaN(current_selection) || null == current_selection || (++current_selection >= result_suggestions.length) )
               current_selection = 0;
 
             options['currentSelection'] = current_selection;


### PR DESCRIPTION
Using the down arrow for navigating the autocomplete list after selecting an item will always select the second item first. This happens for all autocomplete enabled inputs with a drop down on the example page (http://laktek.github.com/jQuery-Smart-Auto-Complete/demo/index.html). Steps for reproducing:

In the input, enter text that will generate at least two results
Hit the down arrow once, the first result is selected as expected
Hit enter to select the item
Delete the text from the input
In the same input, enter the same text that was entered before to generate at least two results
Hit the down arrow once, the second result will be selected
