### PR TITLE
Provide target element for filter query funciton

### DIFF
--- a/jquery.smart_autocomplete.js
+++ b/jquery.smart_autocomplete.js
@@ -162,7 +162,7 @@
 
         //call the filter function with delay
         setTimeout(function(){
-          $.when( filter.apply(options, [query, options.source]) ).done(function( results ){
+          $.when( filter.apply(options, [query, options.source, context]) ).done(function( results ){
             //do the trimming
             var trimmed_results = (options.maxResults > 0 ? results.splice(0, options.maxResults) : results);
 


### PR DESCRIPTION
This is required if you need to get target element attribute values. For examples need to send dynamic data attributes values to ajax request. 
